### PR TITLE
BUG: Corrigir fonte padrão do site 

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,7 +3,7 @@
 @tailwind utilities;
 
 body {
-    font-family: Arial, Helvetica, sans-serif;
+    font-family: DM Sans, sans-serif;
 }
 
 @layer base {


### PR DESCRIPTION
## Task Context

Durante a navegação percebemos que alguns dos componentes  com a fonte errada. 

## Changes

- Ajuste da fonte padrão no arquivo `global.css`

## Screenshots :
Antes: 
![Captura de tela 2025-03-19 112817](https://github.com/user-attachments/assets/fdd67f02-6999-4c5b-b80a-b1812db4d9f5)
Depois: 
![Captura de tela 2025-03-19 112911](https://github.com/user-attachments/assets/c7125d63-0234-4848-b8e7-4bf7fac4a814)

## Card
[Fonte padrão do site](https://app.clickup.com/t/868d0b1wa)


Refs: 868d0b1wa