### PR TITLE
BUG: Ajustar borda do menu [mobile]

### DIFF
--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -38,7 +38,7 @@ const sheetVariants = cva(
                 top: 'inset-x-0 top-0 border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top',
                 bottom: 'inset-x-0 bottom-0 border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom',
                 left: 'inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm',
-                right: 'inset-y-0 right-0 h-full w-3/4 border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm',
+                right: 'inset-y-0 right-0 h-full w-3/4 border-l-foreground/10 data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm',
             },
         },
         defaultVariants: {

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -38,7 +38,7 @@ const sheetVariants = cva(
                 top: 'inset-x-0 top-0 border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top',
                 bottom: 'inset-x-0 bottom-0 border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom',
                 left: 'inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm',
-                right: 'inset-y-0 right-0 h-full w-3/4 border-l-foreground/10 data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm',
+                right: 'inset-y-0 right-0 h-full w-3/4 border-l border-foreground/10 data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm',
             },
         },
         defaultVariants: {


### PR DESCRIPTION
## Task Context

Durante a navegação percebemos que quando na versão mobile o menu estava com uma borda branca no lado esquerdo do container. 

## Changes

- Ajuste da cor da borda no arquivo `sheet.tsx`

## Screenshots :
Antes: 
![Captura de tela 2025-03-19 115702](https://github.com/user-attachments/assets/7bed8bc5-00a2-4fa4-b08d-818de8bcae81)

Depois: 
![image](https://github.com/user-attachments/assets/f09d761f-2c33-44bc-89a5-d280c3aab394)

## Card
[Borda esquerda no menu mobile](https://app.clickup.com/t/868d2fz98)


Refs: 868d2fz98