### PR TITLE
BUG: Marcar Home como ativo ao entrar no site

### DIFF
--- a/src/components/menu-navigation-link.tsx
+++ b/src/components/menu-navigation-link.tsx
@@ -1,7 +1,9 @@
 'use client'
+
 import { cn } from '@/lib/utils'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
+
 import { buttonVariants } from './ui/button'
 import { NavigationMenuLink } from './ui/navigation-menu'
 import { SheetClose } from './ui/sheet'
@@ -25,10 +27,11 @@ export function MenuNavigationLink({
             {type === 'desktop' ? (
                 <Link href={href} legacyBehavior passHref>
                     <NavigationMenuLink
-                        className={
-                            className ||
-                            `inline-flex h-9 w-max items-center justify-center rounded-md px-4 py-2 text-lg font-medium transition-colors hover:bg-accent focus:bg-accent focus:text-accent-foreground focus:outline-none disabled:pointer-events-none disabled:opacity-50 data-[active]:bg-accent/50 data-[state=open]:bg-accent/50`
-                        }
+                        data-actual={href === pathname}
+                        className={cn(
+                            `inline-flex h-9 w-max items-center justify-center rounded-md px-4 py-2 text-lg font-medium transition-colors duration-300 hover:bg-accent focus:bg-accent focus:text-accent-foreground focus:outline-none disabled:pointer-events-none disabled:opacity-50 data-[actual=true]:bg-accent/50`,
+                            className
+                        )}
                     >
                         {title}
                     </NavigationMenuLink>


### PR DESCRIPTION
**Tarefa:** [868d2g0dz](https://app.clickup.com/t/868d2g0dz)

**Descrição:** Ao entrar na página o menu de navegação não indica o link ativo e ao navegar o hover do link permanece, quando clicado em outro local a marcação desaparece.

**Antes:**

![Vídeo sem título (3)](https://github.com/user-attachments/assets/797f3bce-0276-42a9-9571-03d5ad5deb89)

**Após correção:**

![Vídeo sem título (2)](https://github.com/user-attachments/assets/cc71e644-ea28-4738-972b-e531f3063aa5)

Link: [Preview](https://labyes-lp-git-868d2g0dz-headeractivehomelink-dam450s-projects.vercel.app/)
