### PR TITLE
BUG: Ajustar acessibilidade visual (TAB) no header 

### DIFF
--- a/src/components/menu-navigation-desktop.tsx
+++ b/src/components/menu-navigation-desktop.tsx
@@ -30,10 +30,12 @@ export function MenuNavigationDesktop() {
                 </NavigationMenuList>
             </NavigationMenu>
 
-            <Button className="rounded-full text-lg font-bold" size={'lg'}>
-                <Link className="" href="/contato" legacyBehavior passHref>
-                    Fale conosco
-                </Link>
+            <Button
+                asChild
+                className="rounded-full border-2 border-transparent text-lg font-bold focus:border-primary focus:bg-primary/50"
+                size={'lg'}
+            >
+                <Link href="/contato">Fale conosco</Link>
             </Button>
         </div>
     )


### PR DESCRIPTION
tarefa: [868d2fzyj](https://app.clickup.com/t/868d2fzyj)

Descrição: 
Ao usar tecla tab para selecionar o link na navegação existem duas paradas de stop no botão de contato, com identificação visual dentro do botão.

antes:
![Vídeo sem título (4)](https://github.com/user-attachments/assets/0d6dbf11-ae9e-40d4-a175-7a9443ecebe5)

depois:
![Vídeo sem título (5)](https://github.com/user-attachments/assets/ed4e29ef-ccc1-494f-a3a3-9ecd4434b56f)

Link: [preview](https://labyes-lp-git-868d2fzyj-headertabstops-dam450s-projects.vercel.app/)